### PR TITLE
Extended configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,15 @@ repos:
     title: My Repository 1
     image: images/icon-repo-1.png
     url: https://github.com/giansalex/mkdocs-sample.git
+    mkdocs_dir: '.'
   - name: repo-2
     title: My Repository 2
     image: images/icon-repo-2.png
     url: https://github.com/hristo-mavrodiev/mkdocs-sample.git
+    branch: testing
 element_id: multirepo
 target_dir: site
+repos_dir: repositories
 extra_files:
     - styles.css
 ```
@@ -77,10 +80,14 @@ Each entry under `repos` configures an MkDocs project:
 - `title`: Text for the landing page list item.
 - `image`: Image for the landing page list item.
 - `url`: URL of the repository.
+- 'branch': Branch of the repository. Default: empty (which is `master` for most of the repositories).
+- 'mkdocs_dir': Directory (within repo) where the mkdocs directory structure is located. Default: '.'.
 
 `element_id`: ID of the DOM element on the landing page where the links to the projects should be created. Default: `multirepo`.
 
 `target_dir`: Output directory. Default: `site`.
+
+`repos_dir`: Target directory for repositories (submodules). Default: `repositories`.
 
 `extra_files`: Additional files to be placed in the output directory.
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Each entry under `repos` configures an MkDocs project:
 - 'branch': Branch of the repository. Default: empty (which is `master` for most of the repositories).
 - 'mkdocs_dir': Directory (within repo) where the mkdocs directory structure is located. Default: '.'.
 - 'index_html': Index html file for this repository. Default: 'index.html'.
+- 'pdf': Link to pdf file. 
 
 `element_id`: ID of the DOM element on the landing page where the links to the projects should be created. Default: `multirepo`.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Each entry under `repos` configures an MkDocs project:
 - `url`: URL of the repository.
 - 'branch': Branch of the repository. Default: empty (which is `master` for most of the repositories).
 - 'mkdocs_dir': Directory (within repo) where the mkdocs directory structure is located. Default: '.'.
+- 'mkdocs_config': Mkdocs config file used during `mkdocs build`. Default: 'mkdocs.yml'.
 - 'index_html': Index html file for this repository. Default: 'index.html'.
 - 'pdf': Link to pdf file.
 - 'element_id': ID of the DOM element on the landing page where the links to the this repo project should be created. Default: from config.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Each entry under `repos` configures an MkDocs project:
 - `url`: URL of the repository.
 - 'branch': Branch of the repository. Default: empty (which is `master` for most of the repositories).
 - 'mkdocs_dir': Directory (within repo) where the mkdocs directory structure is located. Default: '.'.
+- 'index_html': Index html file for this repository. Default: 'index.html'.
 
 `element_id`: ID of the DOM element on the landing page where the links to the projects should be created. Default: `multirepo`.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Each entry under `repos` configures an MkDocs project:
 - 'branch': Branch of the repository. Default: empty (which is `master` for most of the repositories).
 - 'mkdocs_dir': Directory (within repo) where the mkdocs directory structure is located. Default: '.'.
 - 'index_html': Index html file for this repository. Default: 'index.html'.
-- 'pdf': Link to pdf file. 
+- 'pdf': Link to pdf file.
+- 'element_id': ID of the DOM element on the landing page where the links to the this repo project should be created. Default: from config.
 
 `element_id`: ID of the DOM element on the landing page where the links to the projects should be created. Default: `multirepo`.
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ repos:
     image: images/icon-repo-2.png
     url: https://github.com/hristo-mavrodiev/mkdocs-sample.git
     branch: testing
+    index_html: 01_index.html
 element_id: multirepo
 target_dir: site
 repos_dir: repositories
+index_tpl: index.tpl
 extra_files:
     - styles.css
 ```
@@ -92,7 +94,7 @@ Each entry under `repos` configures an MkDocs project:
 
 `extra_files`: Additional files to be placed in the output directory.
 
-`index`: Path to index template. Default: `index.tpl`
+`index_tpl`: Path to index template. Default: `index.tpl`
 
 ### index.tpl
 
@@ -126,7 +128,7 @@ Sample output:
         <section id="multirepo">
             <ul>
                 <li><a href="repo-1/index.html"><img src="images/icon-repo-1.png" /><span>My Repository 1</span></a></li>
-                <li><a href="repo-2/index.html"><img src="images/icon-repo-2.png" /><span>My Repository 2</span></a></li>
+                <li><a href="repo-2/01_index.html"><img src="images/icon-repo-2.png" /><span>My Repository 2</span></a></li>
             </ul>
         </section>
     </body>

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Each entry under `repos` configures an MkDocs project:
 
 `extra_files`: Additional files to be placed in the output directory.
 
+`index`: Path to index template. Default: `index.tpl`
+
 ### index.tpl
 
 Use the `index.tpl` file to configure the landing page. Example:

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -82,8 +82,11 @@ def cli(init, update, build):
         element.insert(1, soup.new_tag("ul"))
         for repo in config["repos"]:
             # Add a list item for each repo
+            index_html = "index.html"
+            if "index_html" in repo:
+                index_html = repo["index_html"]
             list_tag = soup.new_tag("li")
-            anchor_tag = soup.new_tag("a", href=repo["name"] + "/index.html")
+            anchor_tag = soup.new_tag("a", href=repo["name"] + "/" + index_html)
             image_tag = soup.new_tag("img", src=repo["image"])
             heading_tag = soup.new_tag("span")
             heading_tag.string = repo["title"]

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -83,8 +83,10 @@ def cli(init, update, build):
         for repo in config["repos"]:
             # Add a list item for each repo
             index_html = "index.html"
+
             if "index_html" in repo:
                 index_html = repo["index_html"]
+
             list_tag = soup.new_tag("li")
             anchor_tag = soup.new_tag("a", href=repo["name"] + "/" + index_html)
             image_tag = soup.new_tag("img", src=repo["image"])
@@ -93,8 +95,12 @@ def cli(init, update, build):
 
             anchor_tag.insert(1, image_tag)
             anchor_tag.insert(1, heading_tag)
-
             list_tag.insert(1, anchor_tag)
+
+            if "pdf" in repo:
+                a_tag = soup.new_tag("a", href=repo["name"] + "/" + repo["pdf"])
+                a_tag.string = 'pdf'
+                list_tag.insert(1, a_tag)
 
             element.ul.insert(1, list_tag)
 

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -79,10 +79,17 @@ def cli(init, update, build):
         soup = loadTemplate(config["index_tpl"])
         # Add unordered list as child of element_id
         element = soup.find(id=config["element_id"])
-        element.insert(1, soup.new_tag("ul"))
+        if element.ul is None:
+            element.insert(1, soup.new_tag("ul"))
         for repo in config["repos"]:
             # Add a list item for each repo
             index_html = "index.html"
+
+            repo_element = element
+            if "element_id" in repo:
+                repo_element = soup.find(id=repo["element_id"])
+                if repo_element.ul is None:
+                    repo_element.insert(1, soup.new_tag("ul"))
 
             if "index_html" in repo:
                 index_html = repo["index_html"]
@@ -102,7 +109,7 @@ def cli(init, update, build):
                 a_tag.string = 'pdf'
                 list_tag.insert(1, a_tag)
 
-            element.ul.insert(1, list_tag)
+            repo_element.ul.insert(1, list_tag)
 
         # Write index.html
         with open(config["target_dir"] + "/index.html", "w", encoding="utf8") as htmlfile:

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -76,7 +76,7 @@ def cli(init, update, build):
 
         # Generate index.html based on template
         click.echo("Generating landing page ...")
-        soup = loadTemplate(config["index"])
+        soup = loadTemplate(config["index_tpl"])
         # Add unordered list as child of element_id
         element = soup.find(id=config["element_id"])
         element.insert(1, soup.new_tag("ul"))
@@ -115,8 +115,8 @@ def loadConfig():
             config["target_dir"] = "site"
         if not "element_id" in config:
             config["element_id"] = "multirepo" 
-        if not "index" in config:
-            config["index"] = "index.tpl" 
+        if not "index_tpl" in config:
+            config["index_tpl"] = "index.tpl" 
 
     finally:
         configfile.close()

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -67,7 +67,7 @@ def cli(init, update, build):
 
             repo_site_dir = os.path.abspath(config["target_dir"] + os.path.sep + repo["name"])
             os.chdir(repo_dir + os.path.sep + repo["mkdocs_dir"])
-            os.system("mkdocs build --config " + repo["mkdocs_config"] + " --site-dir " + repo_site_dir)
+            os.system("mkdocs build --config-file " + repo["mkdocs_config"] + " --site-dir " + repo_site_dir)
             os.chdir(cwd)
 
         # Copy extra files

--- a/mkdocs_multirepo/__init__.py
+++ b/mkdocs_multirepo/__init__.py
@@ -57,6 +57,9 @@ def cli(init, update, build):
             repo_dir = os.path.abspath(config["repos_dir"] + os.path.sep + repo["name"])
             if not "mkdocs_dir" in repo:
                 repo["mkdocs_dir"] = "."
+            if not "mkdocs_config" in repo:
+                repo["mkdocs_config"] = "mkdocs.yml"
+            
 
             repo_target_image = os.path.abspath(config["target_dir"] + os.path.sep + repo["image"])
             os.makedirs(os.path.dirname(repo_target_image), exist_ok=True)
@@ -64,7 +67,7 @@ def cli(init, update, build):
 
             repo_site_dir = os.path.abspath(config["target_dir"] + os.path.sep + repo["name"])
             os.chdir(repo_dir + os.path.sep + repo["mkdocs_dir"])
-            os.system("mkdocs build --site-dir " + repo_site_dir)
+            os.system("mkdocs build --config " + repo["mkdocs_config"] + " --site-dir " + repo_site_dir)
             os.chdir(cwd)
 
         # Copy extra files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@
 
 [tool.poetry]
 name = "mkdocs-multirepo"
-version = "0.4.2"
+version = "0.4.3"
 description = ""
-authors = ["Lars Wilhelmer"]
+authors = ["Lars Wilhelmer", "Jozef Fulop"]
 license = "MIT"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Hello,

I have used your codebase (thank you!) and adapted the plugin to my needs.
Mainly, I have added some new config options (for both: global, and repository level) which is visible/documented in README.md.

Now you can :

- Repository Config:
  - specify a branch of each document repository (master by default)
  - specify a location (directory) within the project where the documentation resides (project root directory by default)
  - specify which config should be used (mkdocs.yml by default)
  - URI to index file (index.html by default)
  - element_id for the repo (use global element_id if not specified)
  - optional URI to pdf file (None by default)
  
 - Global Config:
   - specify localtion of index.tpl (index.tpl by default)
   - specify the location of submdules in your working directory